### PR TITLE
Layout Add Customer and Edit Customer screens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ yarn-error.*
 
 # typescript
 *.tsbuildinfo
+
+# VSCode
+.vscode/

--- a/App.tsx
+++ b/App.tsx
@@ -1,4 +1,6 @@
 import React from "react";
+import * as eva from "@eva-design/eva";
+import { ApplicationProvider } from "@ui-kitten/components";
 import { NavigationContainer } from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { Welcome } from "./src/screens/Welcome";
@@ -30,39 +32,41 @@ const RootStack = createNativeStackNavigator();
 
 export default function App() {
   return (
-    <NavigationContainer>
-      <RootStack.Navigator initialRouteName={Screen.Welcome}>
-        <RootStack.Screen
-          name={Screen.Welcome}
-          component={Welcome}
-          options={{ title: "Welcome" }}
-        />
-        <RootStack.Screen
-          name={Screen.RegionList}
-          component={RegionList}
-          options={{ title: "Regions" }}
-        />
-        <RootStack.Screen
-          name={Screen.CustomerList}
-          component={CustomerList}
-          options={{ title: "Customers" }}
-        />
-        <RootStack.Screen
-          name={Screen.ViewCustomer}
-          component={ViewCustomer}
-          options={{ title: "View Customer" }}
-        />
-        <RootStack.Screen
-          name={Screen.EditCustomer}
-          component={EditCustomer}
-          options={{ title: "Edit Customer" }}
-        />
-        <RootStack.Screen
-          name={Screen.AddCustomer}
-          component={AddCustomer}
-          options={{ title: "Add Customer" }}
-        />
-      </RootStack.Navigator>
-    </NavigationContainer>
+    <ApplicationProvider {...eva} theme={eva.light}>
+      <NavigationContainer>
+        <RootStack.Navigator initialRouteName={Screen.Welcome}>
+          <RootStack.Screen
+            name={Screen.Welcome}
+            component={Welcome}
+            options={{ title: "Welcome" }}
+          />
+          <RootStack.Screen
+            name={Screen.RegionList}
+            component={RegionList}
+            options={{ title: "Regions" }}
+          />
+          <RootStack.Screen
+            name={Screen.CustomerList}
+            component={CustomerList}
+            options={{ title: "Customers" }}
+          />
+          <RootStack.Screen
+            name={Screen.ViewCustomer}
+            component={ViewCustomer}
+            options={{ title: "View Customer" }}
+          />
+          <RootStack.Screen
+            name={Screen.EditCustomer}
+            component={EditCustomer}
+            options={{ title: "Edit Customer" }}
+          />
+          <RootStack.Screen
+            name={Screen.AddCustomer}
+            component={AddCustomer}
+            options={{ title: "Add Customer" }}
+          />
+        </RootStack.Navigator>
+      </NavigationContainer>
+    </ApplicationProvider>
   );
 }

--- a/README.md
+++ b/README.md
@@ -47,34 +47,6 @@ This project is completed as part of Udacity's [React Native](https://www.udacit
 
 ## Task breakdown
 
-### Design add customer screen
-
-#### Description
-
-Fully lay out the add customer screen and implement any existing global styles, as well as add any new styles required.
-
-Data to be collected on each customer is:
-- First name (edit text)
-- Last name (edit text)
-- Region (dropdown, regions may be hardcoded)
-- Active status (switch)
-
-#### Acceptance criteria
-
-- The add customer screen should be fully designed, and navigation should continue to work as expected.
-- As this screen will work similarly to the edit customer screen, any shared form components should be kept separately in the `components` directory so that they may be reused.
-
-### Design edit customer screen
-
-#### Description
-
-Fully lay out the edit customer screen and implement any existing global styles, as well as add any new styles required.
-
-#### Acceptance criteria
-
-- The edit customer screen should be fully designed, and navigation should continue to work as expected.
-- This should utilize any shared components created as part of the add customer screen.
-
 ### Set up data store
 
 #### Description

--- a/app.json
+++ b/app.json
@@ -11,9 +11,7 @@
       "resizeMode": "contain",
       "backgroundColor": "#ffffff"
     },
-    "assetBundlePatterns": [
-      "**/*"
-    ],
+    "assetBundlePatterns": ["**/*"],
     "ios": {
       "supportsTablet": true
     },
@@ -24,7 +22,12 @@
       }
     },
     "web": {
-      "favicon": "./assets/favicon.png"
+      "favicon": "./assets/favicon.png",
+      "build": {
+        "babel": {
+          "include": ["@ui-kitten/components"]
+        }
+      }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,11 @@
       "name": "udacity-react-native-project",
       "version": "1.0.0",
       "dependencies": {
+        "@eva-design/eva": "^2.2.0",
         "@expo/metro-runtime": "~3.1.3",
         "@react-navigation/native": "^6.1.17",
         "@react-navigation/native-stack": "^6.9.26",
+        "@ui-kitten/components": "^5.3.1",
         "expo": "~50.0.14",
         "expo-status-bar": "~1.11.1",
         "react": "18.2.0",
@@ -18,6 +20,7 @@
         "react-native": "0.73.6",
         "react-native-safe-area-context": "4.8.2",
         "react-native-screens": "~3.29.0",
+        "react-native-svg": "14.1.0",
         "react-native-web": "~0.19.6"
       },
       "devDependencies": {
@@ -2034,6 +2037,21 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@eva-design/dss": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@eva-design/dss/-/dss-2.2.0.tgz",
+      "integrity": "sha512-ip+iLpe8WFR1IyPGR9puJtXhkZQrWV9p+Xgg3u/3ruDNaObh/YlnfZdS0i29m6YZduW3I+lLuXSXwq5f4pAbRA=="
+    },
+    "node_modules/@eva-design/eva": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@eva-design/eva/-/eva-2.2.0.tgz",
+      "integrity": "sha512-Wh98ex5cCK+YYSQNpthX1bT4CA3zDRR1WnJv0YlyvULAkmjaEvqtoGMCXzu5DH8v1fGIggu/OpAokLS7UVPe+A=="
+    },
+    "node_modules/@eva-design/processor": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@eva-design/processor/-/processor-2.2.0.tgz",
+      "integrity": "sha512-fEvjvilmF/R9dqXDiMoaoXxrPIb5s1APVXbacXKAxjlWl231rzOxc5sdTtJPoFTTEon5KeaKwLHtbQvz5eVvIA=="
     },
     "node_modules/@expo/bunyan": {
       "version": "4.0.0",
@@ -6277,6 +6295,21 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ=="
     },
+    "node_modules/@ui-kitten/components": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@ui-kitten/components/-/components-5.3.1.tgz",
+      "integrity": "sha512-Oj1WePUQtpNfH7ftXGdkkFVmJI+JcR3cBryPJV0E+JAUdH2dbJ0oG/VA+UAgk27/u0K0OZSUkdMFuGnkDAVuYA==",
+      "dependencies": {
+        "@eva-design/dss": "^2.2.0",
+        "@eva-design/processor": "^2.2.0",
+        "fecha": "3.0.3",
+        "hoist-non-react-statics": "^3.2.1",
+        "lodash.merge": "^4.6.1"
+      },
+      "peerDependencies": {
+        "react-native-svg": "*"
+      }
+    },
     "node_modules/@urql/core": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/@urql/core/-/core-2.3.6.tgz",
@@ -6794,6 +6827,11 @@
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.19.0.tgz",
       "integrity": "sha512-DRQrD6gJyy8FbiE4s+bDoXS9hiW3Vbx5uCdwvcCf3zLHL+Iv7LtGHLpr+GZV8rHG8tK766FGYBwRbu8pELTt+w=="
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
     },
     "node_modules/bplist-creator": {
       "version": "0.1.0",
@@ -7476,6 +7514,52 @@
         "hyphenate-style-name": "^1.0.3"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
+      "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
+      "dependencies": {
+        "mdn-data": "2.0.14",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/css-tree/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
@@ -7688,6 +7772,57 @@
         "node": ">=8"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ]
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/dotenv": {
       "version": "16.0.3",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
@@ -7733,6 +7868,17 @@
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-editor": {
@@ -8173,6 +8319,11 @@
       "resolved": "https://registry.npmjs.org/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz",
       "integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ=="
     },
+    "node_modules/fecha": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-3.0.3.tgz",
+      "integrity": "sha512-6LQK/1jud/FZnfEEZJ7y81vw7ge81DNd/XEsX0hgMUjhS+QMljkb1C0czBaP7dMNRVrd5mw/J2J7qI2Nw+TWZw=="
+    },
     "node_modules/fetch-retry": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/fetch-retry/-/fetch-retry-4.1.1.tgz",
@@ -8529,6 +8680,19 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/hosted-git-info": {
       "version": "3.0.8",
@@ -10032,6 +10196,11 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
     },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+    },
     "node_modules/lodash.throttle": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
@@ -10299,6 +10468,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/md5hex/-/md5hex-1.0.0.tgz",
       "integrity": "sha512-c2YOUbp33+6thdCUi34xIyOU/a7bvGKj/3DB1iaPMTuPHf/Q2d5s4sn1FaCOO43XkXggnb08y5W2PU8UNYNLKQ=="
+    },
+    "node_modules/mdn-data": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
+      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow=="
     },
     "node_modules/memoize-one": {
       "version": "5.2.1",
@@ -11118,6 +11292,17 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
     "node_modules/nullthrows": {
@@ -11995,6 +12180,19 @@
       "dependencies": {
         "react-freeze": "^1.0.0",
         "warn-once": "^0.1.0"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-svg": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-14.1.0.tgz",
+      "integrity": "sha512-HeseElmEk+AXGwFZl3h56s0LtYD9HyGdrpg8yd9QM26X+d7kjETrRQ9vCjtxuT5dCZEIQ5uggU1dQhzasnsCWA==",
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "css-tree": "^1.1.3"
       },
       "peerDependencies": {
         "react": "*",

--- a/package.json
+++ b/package.json
@@ -9,9 +9,11 @@
     "web": "expo start --web"
   },
   "dependencies": {
+    "@eva-design/eva": "^2.2.0",
     "@expo/metro-runtime": "~3.1.3",
     "@react-navigation/native": "^6.1.17",
     "@react-navigation/native-stack": "^6.9.26",
+    "@ui-kitten/components": "^5.3.1",
     "expo": "~50.0.14",
     "expo-status-bar": "~1.11.1",
     "react": "18.2.0",
@@ -19,7 +21,8 @@
     "react-native": "0.73.6",
     "react-native-safe-area-context": "4.8.2",
     "react-native-screens": "~3.29.0",
-    "react-native-web": "~0.19.6"
+    "react-native-web": "~0.19.6",
+    "react-native-svg": "14.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/src/components/buttons.tsx
+++ b/src/components/buttons.tsx
@@ -39,3 +39,19 @@ export const SecondaryButton: React.FC<ButtonProps> = ({
     </Pressable>
   );
 };
+
+export const DangerousButton: React.FC<ButtonProps> = ({
+  text,
+  onPress,
+  onLongPress,
+}) => {
+  return (
+    <Pressable
+      onPress={onPress}
+      onLongPress={onLongPress}
+      style={appStyles.dangerousButton}
+    >
+      <Text style={appStyles.dangerousButtonText}>{text}</Text>
+    </Pressable>
+  );
+};

--- a/src/components/customerDataForm.tsx
+++ b/src/components/customerDataForm.tsx
@@ -1,0 +1,175 @@
+import React, { useEffect } from "react";
+import { Pressable, StyleSheet, Text, TextInput, View } from "react-native";
+import { AppColor, appStyles } from "../styles/main";
+import { PrimaryButton, SecondaryButton, DangerousButton } from "./buttons";
+import {
+  IndexPath,
+  Layout as Dropdown,
+  Select,
+  SelectItem,
+  Toggle,
+} from "@ui-kitten/components";
+
+// TODO replace with Redux generated regions to ensure one source of truth
+const allRegions = ["Eastern", "Central", "Mountain", "Pacific"];
+
+const styles = StyleSheet.create({
+  container: {
+    ...appStyles.container,
+    justifyContent: "flex-start",
+    alignItems: "flex-start",
+    padding: 48,
+    gap: 32,
+  },
+  inputContainer: {
+    flexDirection: "row",
+    alignItems: "center",
+    width: "100%",
+  },
+  inputLabel: {
+    width: "40%",
+  },
+  input: {
+    width: "60%",
+    height: 40,
+  },
+  textInput: {
+    borderWidth: 1,
+    borderColor: "#D3D3D3",
+    borderRadius: 5,
+    padding: 10,
+  },
+  dropdownInput: {
+    fontFamily: "inherit",
+  },
+  toggleInput: {
+    justifyContent: "flex-end",
+  },
+  section: {
+    gap: 8,
+  },
+  actionContainer: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+  },
+  actionText: {
+    color: AppColor.Primary,
+  },
+});
+
+interface CustomerDataFormProps {
+  existingFirstName?: string;
+  existingLastName?: string;
+  existingRegion?: number;
+  existingIsActive?: boolean;
+  canDelete: boolean;
+}
+
+export const CustomerDataForm: React.FC<CustomerDataFormProps> = ({
+  existingFirstName,
+  existingLastName,
+  existingRegion,
+  existingIsActive,
+  canDelete,
+}) => {
+  const [firstName, setFirstName] = React.useState(existingFirstName ?? "");
+  const [lastName, setLastName] = React.useState(existingLastName ?? "");
+  const [region, setRegion] = React.useState(existingRegion ?? 0);
+  const [isActive, setIsActive] = React.useState(existingIsActive ?? true);
+
+  const [dropdownIndexPath, setDropdownIndexPath] = React.useState<IndexPath>(
+    new IndexPath(region)
+  );
+
+  useEffect(() => {
+    setRegion(dropdownIndexPath.row);
+  }, [dropdownIndexPath.row]);
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.inputContainer}>
+        <Text style={styles.inputLabel}>First name:</Text>
+        <TextInput
+          style={{
+            ...styles.input,
+            ...styles.textInput,
+          }}
+          onChangeText={setFirstName}
+          value={firstName}
+        />
+      </View>
+      <View style={styles.inputContainer}>
+        <Text style={styles.inputLabel}>Last name:</Text>
+        <TextInput
+          style={{
+            ...styles.input,
+            ...styles.textInput,
+          }}
+          onChangeText={setLastName}
+          value={lastName}
+        />
+      </View>
+      <View style={styles.inputContainer}>
+        <Text style={styles.inputLabel}>Region:</Text>
+        <Dropdown
+          style={{
+            ...styles.input,
+            ...styles.dropdownInput,
+          }}
+        >
+          <Select
+            value={allRegions[region]}
+            selectedIndex={dropdownIndexPath as IndexPath}
+            onSelect={(index) => setDropdownIndexPath(index as IndexPath)}
+          >
+            {allRegions.map((region) => (
+              <SelectItem title={region} />
+            ))}
+          </Select>
+        </Dropdown>
+      </View>
+      <View style={styles.inputContainer}>
+        <Text style={styles.inputLabel}>Is active customer:</Text>
+        <Toggle
+          style={{
+            ...styles.input,
+            ...styles.toggleInput,
+          }}
+          checked={isActive}
+          onChange={(isToggledOn) => setIsActive(isToggledOn)}
+        />
+      </View>
+      <View
+        style={{
+          flexDirection: "row",
+          justifyContent: "space-between",
+          width: "100%",
+        }}
+      >
+        <View style={{ flexDirection: "row" }}>
+          <PrimaryButton
+            text="Save"
+            onPress={() => {
+              console.log("Saving customer details");
+            }}
+          />
+          <SecondaryButton
+            text="Cancel"
+            onPress={() => {
+              console.log("Canceling edits");
+            }}
+          />
+        </View>
+        {canDelete && (
+          <DangerousButton
+            text="Delete"
+            onPress={() => {
+              console.log("Deleting customer");
+            }}
+          />
+        )}
+      </View>
+    </View>
+  );
+};

--- a/src/screens/AddCustomer.tsx
+++ b/src/screens/AddCustomer.tsx
@@ -1,24 +1,6 @@
 import React from "react";
-import { Text, View } from "react-native";
-import { appStyles } from "../styles/main";
-import { PrimaryButton } from "../components/buttons";
+import { CustomerDataForm } from "../components/customerDataForm";
 
 export const AddCustomer: React.FC = () => {
-  return (
-    <View style={appStyles.container}>
-      <Text>Add Customer Page</Text>
-      <PrimaryButton
-        text="Save"
-        onPress={() => {
-          console.log("Saving new customer");
-        }}
-      />
-      <PrimaryButton
-        text="Cancel"
-        onPress={() => {
-          console.log("Canceling add");
-        }}
-      />
-    </View>
-  );
+  return <CustomerDataForm canDelete={false} />;
 };

--- a/src/screens/EditCustomer.tsx
+++ b/src/screens/EditCustomer.tsx
@@ -1,24 +1,22 @@
 import React from "react";
-import { Text, View } from "react-native";
-import { appStyles } from "../styles/main";
-import { PrimaryButton } from "../components/buttons";
+import { CustomerDataForm } from "../components/customerDataForm";
 
 export const EditCustomer: React.FC = () => {
+  // TODO replace with data from Redux once implemented
+  const dummyCustomer = {
+    firstName: "Jane",
+    lastName: "Doe",
+    region: 3, // region index, replicates using a region id
+    isActive: true,
+  };
+
   return (
-    <View style={appStyles.container}>
-      <Text>Edit Customer Page</Text>
-      <PrimaryButton
-        text="Save"
-        onPress={() => {
-          console.log("Saving customer details");
-        }}
-      />
-      <PrimaryButton
-        text="Cancel"
-        onPress={() => {
-          console.log("Canceling edits");
-        }}
-      />
-    </View>
+    <CustomerDataForm
+      existingFirstName={dummyCustomer.firstName}
+      existingLastName={dummyCustomer.lastName}
+      existingRegion={dummyCustomer.region}
+      existingIsActive={dummyCustomer.isActive}
+      canDelete={true}
+    />
   );
 };

--- a/src/screens/ViewCustomer.tsx
+++ b/src/screens/ViewCustomer.tsx
@@ -34,7 +34,7 @@ export const ViewCustomer: React.FC = () => {
       gap: 8,
     },
     actionText: {
-      color: AppColor.Accent,
+      color: AppColor.Primary,
     },
   });
 
@@ -68,14 +68,14 @@ export const ViewCustomer: React.FC = () => {
           style={viewCustomerStyles.actionContainer}
           onPress={() => navigate(Screen.EditCustomer)}
         >
-          <Feather name="edit" size={32} color={AppColor.Accent} />
+          <Feather name="edit" size={32} color={AppColor.Primary} />
           <Text style={viewCustomerStyles.actionText}>Edit customer</Text>
         </Pressable>
         <Pressable
           style={viewCustomerStyles.actionContainer}
           onPress={() => console.log("Send local push notification")}
         >
-          <Ionicons name="notifications" size={32} color={AppColor.Accent} />
+          <Ionicons name="notifications" size={32} color={AppColor.Primary} />
           <Text style={viewCustomerStyles.actionText}>
             Set communication reminder
           </Text>

--- a/src/screens/Welcome.tsx
+++ b/src/screens/Welcome.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useNavigation } from "@react-navigation/native";
 import { Text, View } from "react-native";
 import { appStyles } from "../styles/main";
-import { PrimaryButton, SecondaryButton } from "../components/buttons";
+import { PrimaryButton, DangerousButton } from "../components/buttons";
 import { Screen } from "../constants";
 
 export const Welcome: React.FC = () => {
@@ -36,10 +36,10 @@ export const Welcome: React.FC = () => {
         />
       </View>
 
-      <SecondaryButton
+      <DangerousButton
         text="Clear all customer data"
         onPress={() => console.log("Clearing all customer data")}
-      ></SecondaryButton>
+      />
     </View>
   );
 };

--- a/src/styles/main.tsx
+++ b/src/styles/main.tsx
@@ -1,9 +1,9 @@
 import { StyleSheet } from "react-native";
 
 export enum AppColor {
-  Primary = "#AC2B2B",
-  PrimaryLight = "#e79c9f",
-  Accent = "#2bacac",
+  Primary = "#2BACAC",
+  PrimaryLight = "#ddf0f1",
+  Danger = "#ac2b2b",
 }
 
 export const appStyles = StyleSheet.create({

--- a/src/styles/main.tsx
+++ b/src/styles/main.tsx
@@ -38,4 +38,18 @@ export const appStyles = StyleSheet.create({
     color: AppColor.Primary,
     textTransform: "uppercase",
   },
+  dangerousButton: {
+    alignItems: "center",
+    justifyContent: "center",
+    padding: 6,
+    margin: 6,
+    backgroundColor: "#FFFFFF",
+    borderColor: AppColor.Danger,
+    borderWidth: 2,
+  },
+  dangerousButtonText: {
+    color: AppColor.Danger,
+    textTransform: "uppercase",
+    fontWeight: "bold",
+  },
 });


### PR DESCRIPTION
## Changes

- Minor styling updates to color, and adds a new "dangerous" button option for risky operations
- Installs the [UI Kitten](https://akveo.github.io/react-native-ui-kitten/) library that is used to render input components like dropdowns and switches
- Creates a shared `CustomerDataForm` component that renders all of the customer inputs
- Updates the Add Customer and Edit Customer screens to render the shared customer data form

## What it looks like

### Updated Welcome screen with new colors and "dangerous" button
<img src="https://github.com/meggra7/udacity-react-native-project/assets/98534801/0413ce38-28cd-440c-885b-6f5e87fc0f6b" width="50%" />

### Add Customer
<img src="https://github.com/meggra7/udacity-react-native-project/assets/98534801/0b3c5545-d534-47b3-9642-a9624c1937e8" width="50%" />

### Edit Customer
<img src="https://github.com/meggra7/udacity-react-native-project/assets/98534801/b412e247-04c3-4397-afde-0390c62dd34a" width="50%" />

## "Ticket"

### Description

Fully lay out the add and edit customer screens, and implement any existing global styles, as well as add any new styles required.

Data to be collected on each customer is:
- First name (edit text)
- Last name (edit text)
- Region (dropdown, regions may be hardcoded)
- Active status (switch)

### Acceptance criteria

- The add customer screen should be fully designed, and navigation should continue to work as expected.
- Both screens should display the same, shared form components for the data to be collected (outlined above)
- The edit screen should contain an additional option to delete the customer, not found for the add customer screen
- The edit screen should pre-fill the existing customer's information, while the add customer screen should start with blank inputs.