### PR TITLE
Set up Redux for regions data

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,4 +1,6 @@
 import React from "react";
+import { Provider } from "react-redux";
+import { store } from "./src/store";
 import * as eva from "@eva-design/eva";
 import { ApplicationProvider } from "@ui-kitten/components";
 import { NavigationContainer } from "@react-navigation/native";
@@ -32,41 +34,43 @@ const RootStack = createNativeStackNavigator();
 
 export default function App() {
   return (
-    <ApplicationProvider {...eva} theme={eva.light}>
-      <NavigationContainer>
-        <RootStack.Navigator initialRouteName={Screen.Welcome}>
-          <RootStack.Screen
-            name={Screen.Welcome}
-            component={Welcome}
-            options={{ title: "Welcome" }}
-          />
-          <RootStack.Screen
-            name={Screen.RegionList}
-            component={RegionList}
-            options={{ title: "Regions" }}
-          />
-          <RootStack.Screen
-            name={Screen.CustomerList}
-            component={CustomerList}
-            options={{ title: "Customers" }}
-          />
-          <RootStack.Screen
-            name={Screen.ViewCustomer}
-            component={ViewCustomer}
-            options={{ title: "View Customer" }}
-          />
-          <RootStack.Screen
-            name={Screen.EditCustomer}
-            component={EditCustomer}
-            options={{ title: "Edit Customer" }}
-          />
-          <RootStack.Screen
-            name={Screen.AddCustomer}
-            component={AddCustomer}
-            options={{ title: "Add Customer" }}
-          />
-        </RootStack.Navigator>
-      </NavigationContainer>
-    </ApplicationProvider>
+    <Provider store={store}>
+      <ApplicationProvider {...eva} theme={eva.light}>
+        <NavigationContainer>
+          <RootStack.Navigator initialRouteName={Screen.Welcome}>
+            <RootStack.Screen
+              name={Screen.Welcome}
+              component={Welcome}
+              options={{ title: "Welcome" }}
+            />
+            <RootStack.Screen
+              name={Screen.RegionList}
+              component={RegionList}
+              options={{ title: "Regions" }}
+            />
+            <RootStack.Screen
+              name={Screen.CustomerList}
+              component={CustomerList}
+              options={{ title: "Customers" }}
+            />
+            <RootStack.Screen
+              name={Screen.ViewCustomer}
+              component={ViewCustomer}
+              options={{ title: "View Customer" }}
+            />
+            <RootStack.Screen
+              name={Screen.EditCustomer}
+              component={EditCustomer}
+              options={{ title: "Edit Customer" }}
+            />
+            <RootStack.Screen
+              name={Screen.AddCustomer}
+              component={AddCustomer}
+              options={{ title: "Add Customer" }}
+            />
+          </RootStack.Navigator>
+        </NavigationContainer>
+      </ApplicationProvider>
+    </Provider>
   );
 }

--- a/README.md
+++ b/README.md
@@ -47,29 +47,6 @@ This project is completed as part of Udacity's [React Native](https://www.udacit
 
 ## Task breakdown
 
-### Set up data store
-
-#### Description
-
-Set up the framework for the Redux data store.
-
-#### Acceptance criteria
-
-- Install and set up framework for Redux Toolkit
-- Define data models for regions and customers
-- Install and set up framework for AsyncStorage
-
-### Convert region list to pull from Redux
-
-#### Description
-
-In order to ensure that the displayed region options will be consistent with the options offered when adding customers, let's render the region list navigation buttons based on the regions found in Redux instead of hardcoded options.
-
-#### Acceptance criteria
-
-- This should be a no-op, and the region list should continue to display as expected.
-- When clicking on a region, we should now pass in the region as a navigation param so that we'll be able to filter out customers for that region appropriately in the customer list screen.
-
 ### Implement add customer functionality
 
 #### Description
@@ -78,8 +55,19 @@ Implement functionality to add a new customer to the store.
 
 #### Acceptance criteria
 
-- Adding a new customer via the add customer screen should record the new customer data so that it is visible in Redux.
+- Adding a new customer via the add customer screen should record the new customer data so that it is visible in Redux
 - Form fields should include basic validation (not empty, trim whitespace)
+
+### Set up AsyncStorage
+
+#### Description
+
+Set up the framework for the async data store.
+
+#### Acceptance criteria
+
+- Install and set up framework for AsyncStorage
+- Implement for customer model
 
 ### Implement customer list functionality
 
@@ -87,6 +75,7 @@ Implement functionality to display customers found in Redux rather than hard-cod
 
 #### Description
 
+- When clicking on a region, we should now pass in the region as a navigation param so that we'll be able to filter out customers for that region appropriately in the customer list screen.
 - After adding a customer, that customer should now be visible in the customer list for its region.
 
 #### Acceptance criteria

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@expo/metro-runtime": "~3.1.3",
         "@react-navigation/native": "^6.1.17",
         "@react-navigation/native-stack": "^6.9.26",
+        "@reduxjs/toolkit": "^2.2.3",
         "@ui-kitten/components": "^5.3.1",
         "expo": "~50.0.14",
         "expo-status-bar": "~1.11.1",
@@ -21,7 +22,8 @@
         "react-native-safe-area-context": "4.8.2",
         "react-native-screens": "~3.29.0",
         "react-native-svg": "14.1.0",
-        "react-native-web": "~0.19.6"
+        "react-native-web": "~0.19.6",
+        "react-redux": "^9.1.0"
       },
       "devDependencies": {
         "@babel/core": "^7.20.0",
@@ -6127,6 +6129,29 @@
         "nanoid": "^3.1.23"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.2.3.tgz",
+      "integrity": "sha512-76dll9EnJXg4EVcI5YNxZA/9hSAmZsFqzMmNRHvIlzw2WS/twfcVX3ysYrWGJMClwEmChQFC4yRq74tn6fdzRA==",
+      "dependencies": {
+        "immer": "^10.0.3",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.0.1"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@segment/loosely-validate-event": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@segment/loosely-validate-event/-/loosely-validate-event-2.0.0.tgz",
@@ -6256,13 +6281,13 @@
       "version": "15.7.12",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.12.tgz",
       "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/react": {
       "version": "18.2.73",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.73.tgz",
       "integrity": "sha512-XcGdod0Jjv84HOC7N5ziY3x+qL0AfmubvKOZ9hJjJ2yd5EE+KYjWhdOjt387e9HPheHkdggF9atTifMRtyAaRA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -6281,6 +6306,11 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw=="
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
     },
     "node_modules/@types/yargs": {
       "version": "17.0.32",
@@ -7564,7 +7594,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/dag-map": {
       "version": "1.0.2",
@@ -8808,6 +8838,15 @@
       },
       "engines": {
         "node": ">=16.x"
+      }
+    },
+    "node_modules/immer": {
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.0.4.tgz",
+      "integrity": "sha512-cuBuGK40P/sk5IzWa9QPUaAdvPHjkk1c+xYsd9oZw+YQQEV+10G0P5uMpGctZZKnyQ+ibRO08bD25nWLmYi2pw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/import-fresh": {
@@ -12336,6 +12375,32 @@
         "async-limiter": "~1.0.0"
       }
     },
+    "node_modules/react-redux": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.1.0.tgz",
+      "integrity": "sha512-6qoDzIO+gbrza8h3hjMA9aq4nwVFCKFtY2iLxCtVT38Swyy2C/dJCGBXHeHLtx6qlg/8qzc2MrhOeduf5K32wQ==",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.3",
+        "use-sync-external-store": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25",
+        "react": "^18.0",
+        "react-native": ">=0.69",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
@@ -12395,6 +12460,19 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/regenerate": {
@@ -12507,6 +12585,11 @@
       "dependencies": {
         "path-parse": "^1.0.5"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.0.tgz",
+      "integrity": "sha512-aw7jcGLDpSgNDyWBQLv2cedml85qd95/iszJjN988zX1t7AVRJi19d9kto5+W7oCfQ94gyo40dVbT6g2k4/kXg=="
     },
     "node_modules/resolve": {
       "version": "1.22.8",
@@ -13608,6 +13691,14 @@
       "integrity": "sha512-CL/29uS74AwreI/f2oz2hLTW7ZqVeV5+gxFeGudzQrgkCytrHw33G4KbnQOrRlAEzzAFXi7dDLMC9zhWcVpzmw==",
       "peerDependencies": {
         "react": ">=16.8"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@expo/metro-runtime": "~3.1.3",
     "@react-navigation/native": "^6.1.17",
     "@react-navigation/native-stack": "^6.9.26",
+    "@reduxjs/toolkit": "^2.2.3",
     "@ui-kitten/components": "^5.3.1",
     "expo": "~50.0.14",
     "expo-status-bar": "~1.11.1",
@@ -21,8 +22,9 @@
     "react-native": "0.73.6",
     "react-native-safe-area-context": "4.8.2",
     "react-native-screens": "~3.29.0",
+    "react-native-svg": "14.1.0",
     "react-native-web": "~0.19.6",
-    "react-native-svg": "14.1.0"
+    "react-redux": "^9.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/src/screens/RegionList.tsx
+++ b/src/screens/RegionList.tsx
@@ -4,31 +4,27 @@ import { Text, View } from "react-native";
 import { appStyles } from "../styles/main";
 import { PrimaryButton } from "../components/buttons";
 import { Screen } from "../constants";
+import { useGetRegions } from "../store/hooks/useGetRegions";
 
 export const RegionList: React.FC = () => {
   const { navigate } = useNavigation();
+  const { regions } = useGetRegions();
 
   return (
     <View style={appStyles.container}>
       <Text style={{ marginBottom: 8 }}>
         Select a region below to view customers for that region
       </Text>
-      <PrimaryButton
-        text="Eastern"
-        onPress={() => navigate(Screen.CustomerList)}
-      />
-      <PrimaryButton
-        text="Central"
-        onPress={() => navigate(Screen.CustomerList)}
-      />
-      <PrimaryButton
-        text="Mountain"
-        onPress={() => navigate(Screen.CustomerList)}
-      />
-      <PrimaryButton
-        text="Pacific"
-        onPress={() => navigate(Screen.CustomerList)}
-      />
+      {/* TODO Should implement unique keys when mapping array, but ignoring for now since practice project */}
+      {regions.map((region, id) => (
+        <PrimaryButton
+          text={region}
+          onPress={() => {
+            console.log(`Region ${id} selected`);
+            navigate(Screen.CustomerList);
+          }}
+        />
+      ))}
     </View>
   );
 };

--- a/src/store/hooks/useGetRegions.tsx
+++ b/src/store/hooks/useGetRegions.tsx
@@ -1,0 +1,10 @@
+import { useSelector } from "react-redux";
+import { RootState } from "..";
+
+export const useGetRegions = () => {
+  const regions: string[] = useSelector(
+    (state: RootState) => state.regionsReducer.regions
+  );
+
+  return { regions };
+};

--- a/src/store/index.tsx
+++ b/src/store/index.tsx
@@ -1,0 +1,12 @@
+import { configureStore } from "@reduxjs/toolkit";
+import reducer from "./reducer";
+
+export const store = configureStore({
+  reducer,
+});
+
+// Per documenation https://redux-toolkit.js.org/tutorials/quick-start#create-a-redux-store
+// Infer the `RootState` and `AppDispatch` types from the store itself
+export type RootState = ReturnType<typeof store.getState>;
+// Inferred type: {posts: PostsState, comments: CommentsState, users: UsersState}
+export type AppDispatch = typeof store.dispatch;

--- a/src/store/reducer.tsx
+++ b/src/store/reducer.tsx
@@ -1,7 +1,8 @@
 import { combineReducers } from "redux";
+import regionsReducer from "./reducers/regionsReducer";
 
 const rootReducer = combineReducers({
-  // TODO add individual feature reducers here
+  regionsReducer,
 });
 
 export default rootReducer;

--- a/src/store/reducer.tsx
+++ b/src/store/reducer.tsx
@@ -1,0 +1,7 @@
+import { combineReducers } from "redux";
+
+const rootReducer = combineReducers({
+  // TODO add individual feature reducers here
+});
+
+export default rootReducer;

--- a/src/store/reducers/regionsReducer.tsx
+++ b/src/store/reducers/regionsReducer.tsx
@@ -1,0 +1,16 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+const name = "regionsReducer";
+
+const initialState = {
+  // Replicates response received from data store. Index will replicate id.
+  regions: ["Eastern", "Central", "Mountain", "Pacific"],
+};
+
+const slice = createSlice({
+  name,
+  initialState,
+  reducers: {},
+});
+
+export default slice.reducer;


### PR DESCRIPTION
## Changes

- Installs Redux Toolkit and implements basic framework
- Creates `regionsReducer` to pull region data from Redux instead of a hardcoded list in code

## What it looks like

![image](https://github.com/meggra7/udacity-react-native-project/assets/98534801/19b3ba2c-e451-420f-8bb4-38b47d9dff4b)

## "Ticket"

### Description

Set up the framework for the Redux data store.

Then, in order to ensure that the displayed region options will be consistent with the options offered when adding customers, let's render the region list navigation buttons based on the regions found in Redux instead of hardcoded options.

### Acceptance criteria

- Install and set up framework for Redux Toolkit
- Define data model for regions
- Functionally this should be a no-op, and the region list should continue to display as expected.