### PR TITLE
Implement clear all customer data functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,17 +55,9 @@ This task is to primarily ensure that all navigation nuances are wired up correc
 
 #### Acceptance criteria
 
-- TBD
-
-### Implement clear all data functionality
-
-#### Description
-
-Implement functionality to reset all customer data.
-
-#### Acceptance criteria
-
-- Clicking to clear all data from the welcome screen should remove all customer data from the store.
+- Upon successfully adding or editing a customer, navigate to the view customer page for that customer that will navigate back to the region for that customer
+- Upon successfully deleting a customer, navigate to the customer list for that customer's region
+- Upon clicking to add a customer from a specific region list, pass in the region id to pre-populate the region
 
 ### Implement push notifications
 

--- a/src/components/customerDataForm.tsx
+++ b/src/components/customerDataForm.tsx
@@ -205,7 +205,7 @@ export const CustomerDataForm: React.FC<CustomerDataFormProps> = ({
         )}
       </View>
       {(error || errorDeleteCustomer) && (
-        <Text style={{ color: AppColor.Danger }}>
+        <Text style={appStyles.errorText}>
           {error ?? errorDeleteCustomer}
         </Text>
       )}

--- a/src/screens/Welcome.tsx
+++ b/src/screens/Welcome.tsx
@@ -13,6 +13,7 @@ export const Welcome: React.FC = () => {
     syncCustomers,
     resetCustomers,
     isLoadingResetCustomers,
+    errorResetCustomers,
   } = useGetCustomersReducer();
 
   useEffect(() => {
@@ -66,6 +67,12 @@ export const Welcome: React.FC = () => {
         />
       </View>
 
+      {errorResetCustomers && (
+        <Text style={appStyles.errorText}>
+          We're sorry, there was an error clearing the customer data. Please try
+          again later.
+        </Text>
+      )}
       <DangerousButton
         text="Clear all customer data"
         onPress={showClearCustomerDataAlert}

--- a/src/screens/Welcome.tsx
+++ b/src/screens/Welcome.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from "react";
 import { useNavigation } from "@react-navigation/native";
-import { Text, View } from "react-native";
+import { Alert, Text, View } from "react-native";
 import { appStyles } from "../styles/main";
 import { PrimaryButton, DangerousButton } from "../components/buttons";
 import { Screen } from "../constants";
@@ -8,13 +8,35 @@ import { useGetCustomersReducer } from "../store/hooks/useGetCustomersReducer";
 
 export const Welcome: React.FC = () => {
   const { navigate } = useNavigation();
-  const { customers, syncCustomers } = useGetCustomersReducer();
+  const {
+    customers,
+    syncCustomers,
+    resetCustomers,
+    isLoadingResetCustomers,
+  } = useGetCustomersReducer();
 
   useEffect(() => {
     if (!customers) {
       syncCustomers();
     }
   }, []);
+
+  const showClearCustomerDataAlert = () => {
+    Alert.alert(
+      "Clearing All Customer Data",
+      "Are you sure you want to clear ALL customer data? This cannot be undone.",
+      [
+        {
+          text: "Cancel",
+          style: "cancel",
+        },
+        {
+          text: "Yes, clear all customer data",
+          onPress: () => resetCustomers(),
+        },
+      ]
+    );
+  };
 
   return (
     <View
@@ -46,7 +68,8 @@ export const Welcome: React.FC = () => {
 
       <DangerousButton
         text="Clear all customer data"
-        onPress={() => console.log("Clearing all customer data")}
+        onPress={showClearCustomerDataAlert}
+        disabled={isLoadingResetCustomers}
       />
     </View>
   );

--- a/src/store/hooks/useGetCustomersReducer.tsx
+++ b/src/store/hooks/useGetCustomersReducer.tsx
@@ -14,6 +14,12 @@ export const useGetCustomersReducer = () => {
   const errorSyncCustomers = useSelector(
     (state: RootState) => state.customersReducer.errorSyncCustomers
   );
+  const isLoadingResetCustomers = useSelector(
+    (state: RootState) => state.customersReducer.isLoadingResetCustomers
+  );
+  const errorResetCustomers = useSelector(
+    (state: RootState) => state.customersReducer.errorResetCustomers
+  );
   const isLoadingSaveCustomer = useSelector(
     (state: RootState) => state.customersReducer.isLoadingSaveCustomer
   );
@@ -33,6 +39,11 @@ export const useGetCustomersReducer = () => {
     errorSyncCustomers,
     syncCustomers: () => {
       return dispatch(actions.syncCustomers());
+    },
+    isLoadingResetCustomers,
+    errorResetCustomers,
+    resetCustomers: () => {
+      return dispatch(actions.resetCustomers());
     },
     isLoadingSaveCustomer,
     errorSaveCustomer,

--- a/src/store/reducers/customersReducer.tsx
+++ b/src/store/reducers/customersReducer.tsx
@@ -12,6 +12,8 @@ interface CustomersReducerState {
   customers?: Customer[];
   isLoadingSyncCustomers: boolean;
   errorSyncCustomers: string | null;
+  isLoadingResetCustomers: boolean;
+  errorResetCustomers: string | null;
   isLoadingSaveCustomer: boolean;
   errorSaveCustomer: string | null;
   isLoadingDeleteCustomer: boolean;
@@ -23,6 +25,8 @@ const slice = createSlice({
   initialState: {
     isLoadingSyncCustomers: false,
     errorSyncCustomers: null,
+    isLoadingResetCustomers: false,
+    errorResetCustomers: null,
     isLoadingSaveCustomer: false,
     errorSaveCustomer: null,
     isLoadingDeleteCustomer: false,
@@ -40,6 +44,18 @@ const slice = createSlice({
     syncCustomersError: (state, action: PayloadAction<string>) => {
       state.isLoadingSyncCustomers = false;
       state.errorSyncCustomers = action.payload;
+    },
+    resetCustomers: (state) => {
+      state.isLoadingResetCustomers = true;
+      state.errorResetCustomers = null;
+    },
+    resetCustomersResult: (state) => {
+      state.isLoadingResetCustomers = false;
+      state.customers = undefined;
+    },
+    resetCustomersError: (state, action: PayloadAction<string>) => {
+      state.isLoadingResetCustomers = false;
+      state.errorResetCustomers = action.payload;
     },
     saveCustomer: (state, action: PayloadAction<Customer>) => {
       state.isLoadingSaveCustomer = true;
@@ -72,6 +88,9 @@ export const {
   syncCustomers,
   syncCustomersResult,
   syncCustomersError,
+  resetCustomers,
+  resetCustomersResult,
+  resetCustomersError,
   saveCustomer,
   saveCustomerResult,
   saveCustomerError,

--- a/src/store/saga.tsx
+++ b/src/store/saga.tsx
@@ -2,7 +2,13 @@ import { all } from "redux-saga/effects";
 import { watchSaveCustomer } from "./sagas/customers/saveCustomerSaga";
 import { watchSyncCustomers } from "./sagas/customers/syncCustomersSaga";
 import { watchDeleteCustomer } from "./sagas/customers/deleteCustomerSaga";
+import { watchResetCustomers } from "./sagas/customers/resetCustomersSaga";
 
 export default function* rootSaga() {
-  yield all([watchSyncCustomers(), watchSaveCustomer(), watchDeleteCustomer()]);
+  yield all([
+    watchSyncCustomers(),
+    watchResetCustomers(),
+    watchSaveCustomer(),
+    watchDeleteCustomer(),
+  ]);
 }

--- a/src/store/sagas/customers/resetCustomersSaga.tsx
+++ b/src/store/sagas/customers/resetCustomersSaga.tsx
@@ -1,0 +1,17 @@
+import { put, takeLatest, delay } from "redux-saga/effects";
+import * as actions from "../../reducers/customersReducer";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+export function* watchResetCustomers() {
+  yield takeLatest(actions.resetCustomers.toString(), takeResetCustomers);
+}
+
+export function* takeResetCustomers() {
+  try {
+    yield AsyncStorage.clear();
+    yield put(actions.resetCustomersResult());
+    yield put(actions.syncCustomers());
+  } catch (error: any) {
+    yield put(actions.resetCustomersError(error.toString()));
+  }
+}

--- a/src/styles/main.tsx
+++ b/src/styles/main.tsx
@@ -77,4 +77,9 @@ export const appStyles = StyleSheet.create({
     textTransform: "uppercase",
     fontWeight: "bold",
   },
+  errorText: {
+    color: AppColor.Danger,
+    textAlign: 'center',
+    marginVertical: 8,
+  }
 });


### PR DESCRIPTION
## Changes
- Adds functionality to clear all customer data from the store.

  Note that this action clears ALL of the local store data, not just the `CUSTOMERS` key, but for the sake of including a different async action we're using this synonymously with clearing customer data, as that is all that is implemented for this app.

## What it looks like
https://github.com/meggra7/udacity-react-native-project/assets/98534801/ffae6b49-57c8-46b9-980f-f9cd6a11a02e

## "Ticket"

### Description
Implement functionality to reset all customer data.

### Acceptance criteria
- Clicking to clear all data from the welcome screen should remove all customer data from the store.