### PR TITLE
Polish navigation

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -21,7 +21,7 @@ export type RootStackParamList = {
   CustomerList: { regionId: number };
   ViewCustomer: { customerId: number };
   EditCustomer: { customer: Customer };
-  AddCustomer: undefined;
+  AddCustomer: { regionId: number };
 };
 
 // Per documentation https://reactnavigation.org/docs/typescript/#specifying-default-types-for-usenavigation-link-ref-etc

--- a/README.md
+++ b/README.md
@@ -47,18 +47,6 @@ This project is completed as part of Udacity's [React Native](https://www.udacit
 
 ## Task breakdown
 
-### Confirm all navigation works as expected
-
-#### Description
-
-This task is to primarily ensure that all navigation nuances are wired up correctly.
-
-#### Acceptance criteria
-
-- Upon successfully adding or editing a customer, navigate to the view customer page for that customer that will navigate back to the region for that customer
-- Upon successfully deleting a customer, navigate to the customer list for that customer's region
-- Upon clicking to add a customer from a specific region list, pass in the region id to pre-populate the region
-
 ### Implement push notifications
 
 #### Description

--- a/src/components/customerDataForm.tsx
+++ b/src/components/customerDataForm.tsx
@@ -41,9 +41,6 @@ const styles = StyleSheet.create({
     borderRadius: 5,
     padding: 10,
   },
-  dropdownInput: {
-    fontFamily: "inherit",
-  },
   toggleInput: {
     justifyContent: "flex-end",
   },
@@ -187,19 +184,14 @@ export const CustomerDataForm: React.FC<CustomerDataFormProps> = ({
       </View>
       <View style={styles.inputContainer}>
         <Text style={styles.inputLabel}>Region:</Text>
-        <Dropdown
-          style={{
-            ...styles.input,
-            ...styles.dropdownInput,
-          }}
-        >
+        <Dropdown style={styles.input}>
           <Select
             value={regions[region]}
             selectedIndex={dropdownIndexPath as IndexPath}
             onSelect={(index) => setDropdownIndexPath(index as IndexPath)}
           >
-            {regions.map((region) => (
-              <SelectItem title={region} />
+            {regions.map((region, index) => (
+              <SelectItem title={region} key={`region-${index}`} />
             ))}
           </Select>
         </Dropdown>

--- a/src/components/customerDataForm.tsx
+++ b/src/components/customerDataForm.tsx
@@ -64,21 +64,18 @@ interface CustomerDataFormProps {
   existingCustomer?: Customer;
   regionIdForNewCustomer?: number;
   canDelete: boolean;
-  isDisabled: boolean;
-  onSave: (customer: Customer) => void;
-  error: string | null;
 }
 
 export const CustomerDataForm: React.FC<CustomerDataFormProps> = ({
   existingCustomer,
   regionIdForNewCustomer,
   canDelete,
-  isDisabled,
-  onSave,
-  error,
 }) => {
   const { navigate, goBack } = useNavigation();
   const {
+    saveCustomer,
+    isLoadingSaveCustomer,
+    errorSaveCustomer,
     deleteCustomer,
     isRequestedDeleteCustomer,
     isLoadingDeleteCustomer,
@@ -102,7 +99,7 @@ export const CustomerDataForm: React.FC<CustomerDataFormProps> = ({
     new IndexPath(region)
   );
 
-  const disableButtons = isDisabled || isLoadingDeleteCustomer;
+  const disableButtons = isLoadingSaveCustomer || isLoadingDeleteCustomer;
 
   useEffect(() => {
     setRegion(dropdownIndexPath.row);
@@ -207,7 +204,7 @@ export const CustomerDataForm: React.FC<CustomerDataFormProps> = ({
           <PrimaryButton
             text="Save"
             onPress={() =>
-              onSave({
+              saveCustomer({
                 firstName,
                 lastName,
                 region,
@@ -231,8 +228,10 @@ export const CustomerDataForm: React.FC<CustomerDataFormProps> = ({
           />
         )}
       </View>
-      {(error || errorDeleteCustomer) && (
-        <Text style={appStyles.errorText}>{error ?? errorDeleteCustomer}</Text>
+      {(errorSaveCustomer || errorDeleteCustomer) && (
+        <Text style={appStyles.errorText}>
+          {errorSaveCustomer ?? errorDeleteCustomer}
+        </Text>
       )}
     </View>
   );

--- a/src/components/customerDataForm.tsx
+++ b/src/components/customerDataForm.tsx
@@ -74,8 +74,10 @@ export const CustomerDataForm: React.FC<CustomerDataFormProps> = ({
   const { navigate, goBack } = useNavigation();
   const {
     saveCustomer,
+    isRequestedSaveCustomer,
     isLoadingSaveCustomer,
     errorSaveCustomer,
+    resetRequestSaveCustomer,
     deleteCustomer,
     isRequestedDeleteCustomer,
     isLoadingDeleteCustomer,
@@ -101,9 +103,29 @@ export const CustomerDataForm: React.FC<CustomerDataFormProps> = ({
 
   const disableButtons = isLoadingSaveCustomer || isLoadingDeleteCustomer;
 
+  const customerToSave: Customer = {
+    firstName,
+    lastName,
+    region,
+    isActive,
+    id: existingCustomer?.id,
+  };
+
   useEffect(() => {
     setRegion(dropdownIndexPath.row);
   }, [dropdownIndexPath.row]);
+
+  useEffect(() => {
+    if (
+      isRequestedSaveCustomer &&
+      !isLoadingSaveCustomer &&
+      !errorSaveCustomer
+    ) {
+      // The requested save was successful. Clear the save request and go back to the customer list.
+      resetRequestSaveCustomer();
+      navigate(Screen.CustomerList, { regionId: customerToSave.region });
+    }
+  }, [isRequestedSaveCustomer, isLoadingSaveCustomer, errorSaveCustomer]);
 
   useEffect(() => {
     if (
@@ -203,15 +225,7 @@ export const CustomerDataForm: React.FC<CustomerDataFormProps> = ({
         <View style={{ flexDirection: "row" }}>
           <PrimaryButton
             text="Save"
-            onPress={() =>
-              saveCustomer({
-                firstName,
-                lastName,
-                region,
-                isActive,
-                id: existingCustomer?.id,
-              })
-            }
+            onPress={() => saveCustomer(customerToSave)}
             disabled={disableButtons}
           />
           <SecondaryButton

--- a/src/components/customerDataForm.tsx
+++ b/src/components/customerDataForm.tsx
@@ -77,7 +77,7 @@ export const CustomerDataForm: React.FC<CustomerDataFormProps> = ({
   onSave,
   error,
 }) => {
-  const { navigate } = useNavigation();
+  const { navigate, goBack } = useNavigation();
   const {
     deleteCustomer,
     isRequestedDeleteCustomer,
@@ -219,9 +219,7 @@ export const CustomerDataForm: React.FC<CustomerDataFormProps> = ({
           />
           <SecondaryButton
             text="Cancel"
-            onPress={() => {
-              console.log("Canceling edits");
-            }}
+            onPress={goBack}
             disabled={disableButtons}
           />
         </View>

--- a/src/components/customerDataForm.tsx
+++ b/src/components/customerDataForm.tsx
@@ -62,6 +62,7 @@ const styles = StyleSheet.create({
 
 interface CustomerDataFormProps {
   existingCustomer?: Customer;
+  regionIdForNewCustomer?: number;
   canDelete: boolean;
   isDisabled: boolean;
   onSave: (customer: Customer) => void;
@@ -70,6 +71,7 @@ interface CustomerDataFormProps {
 
 export const CustomerDataForm: React.FC<CustomerDataFormProps> = ({
   existingCustomer,
+  regionIdForNewCustomer,
   canDelete,
   isDisabled,
   onSave,
@@ -90,7 +92,9 @@ export const CustomerDataForm: React.FC<CustomerDataFormProps> = ({
   const [lastName, setLastName] = React.useState(
     existingCustomer?.lastName ?? ""
   );
-  const [region, setRegion] = React.useState(existingCustomer?.region ?? 0);
+  const [region, setRegion] = React.useState(
+    existingCustomer?.region ?? regionIdForNewCustomer ?? 0
+  );
   const [isActive, setIsActive] = React.useState(
     existingCustomer?.isActive ?? true
   );

--- a/src/screens/AddCustomer.tsx
+++ b/src/screens/AddCustomer.tsx
@@ -1,21 +1,15 @@
 import React from "react";
 import { CustomerDataForm } from "../components/CustomerDataForm";
-import { useGetCustomersReducer } from "../store/hooks/useGetCustomersReducer";
 import { RouteProp, useRoute } from "@react-navigation/native";
 import { RootStackParamList } from "../../App";
 
 export const AddCustomer: React.FC = () => {
   const { params } = useRoute<RouteProp<RootStackParamList, "AddCustomer">>();
-  const { saveCustomer, isLoadingSaveCustomer, errorSaveCustomer } =
-    useGetCustomersReducer();
 
   return (
     <CustomerDataForm
       regionIdForNewCustomer={params.regionId}
       canDelete={false}
-      onSave={saveCustomer}
-      isDisabled={isLoadingSaveCustomer}
-      error={errorSaveCustomer}
     />
   );
 };

--- a/src/screens/AddCustomer.tsx
+++ b/src/screens/AddCustomer.tsx
@@ -1,13 +1,17 @@
 import React from "react";
 import { CustomerDataForm } from "../components/CustomerDataForm";
 import { useGetCustomersReducer } from "../store/hooks/useGetCustomersReducer";
+import { RouteProp, useRoute } from "@react-navigation/native";
+import { RootStackParamList } from "../../App";
 
 export const AddCustomer: React.FC = () => {
+  const { params } = useRoute<RouteProp<RootStackParamList, "AddCustomer">>();
   const { saveCustomer, isLoadingSaveCustomer, errorSaveCustomer } =
     useGetCustomersReducer();
 
   return (
     <CustomerDataForm
+      regionIdForNewCustomer={params.regionId}
       canDelete={false}
       onSave={saveCustomer}
       isDisabled={isLoadingSaveCustomer}

--- a/src/screens/CustomerList.tsx
+++ b/src/screens/CustomerList.tsx
@@ -12,6 +12,40 @@ import { PrimaryButton } from "../components/buttons";
 import { Screen } from "../constants";
 import { RootStackParamList } from "../../App";
 import { useGetCustomersReducer } from "../store/hooks/useGetCustomersReducer";
+import { useGetRegions } from "../store/hooks/useGetRegions";
+
+interface AddCustomerButtonProps {
+  regionId: number;
+}
+
+const AddCustomerButton: React.FC<AddCustomerButtonProps> = ({ regionId }) => {
+  const { navigate } = useNavigation();
+  const { regions } = useGetRegions();
+
+  return (
+    <PrimaryButton
+      text={`Add ${regions[regionId]} Customer`}
+      onPress={() => navigate(Screen.AddCustomer)}
+    />
+  );
+};
+
+interface EmptyCustomerListViewProps {
+  regionId: number;
+}
+
+const EmptyCustomerListView: React.FC<EmptyCustomerListViewProps> = ({
+  regionId,
+}) => {
+  return (
+    <View>
+      <Text style={{ marginBottom: 8 }}>
+        No customers have been added for this region
+      </Text>
+      <AddCustomerButton regionId={regionId} />
+    </View>
+  );
+};
 
 interface CustomerListItemProps {
   id: number;
@@ -48,22 +82,6 @@ const CustomerListItem: React.FC<CustomerListItemProps> = ({
   );
 };
 
-const EmptyCustomerListView: React.FC = () => {
-  const { navigate } = useNavigation();
-
-  return (
-    <View>
-      <Text style={{ marginBottom: 8 }}>
-        No customers have been added for this region
-      </Text>
-      <PrimaryButton
-        text="Add Customer"
-        onPress={() => navigate(Screen.AddCustomer)}
-      />
-    </View>
-  );
-};
-
 export const CustomerList: React.FC = () => {
   const { params } = useRoute<RouteProp<RootStackParamList, "CustomerList">>();
   const { customers } = useGetCustomersReducer();
@@ -84,7 +102,7 @@ export const CustomerList: React.FC = () => {
   if (customersForRegion?.length === 0) {
     return (
       <View style={appStyles.container}>
-        <EmptyCustomerListView />
+        <EmptyCustomerListView regionId={regionId} />
       </View>
     );
   }
@@ -110,6 +128,7 @@ export const CustomerList: React.FC = () => {
           </View>
         ))}
       </ScrollView>
+      <AddCustomerButton regionId={regionId} />
     </View>
   );
 };

--- a/src/screens/CustomerList.tsx
+++ b/src/screens/CustomerList.tsx
@@ -25,7 +25,7 @@ const AddCustomerButton: React.FC<AddCustomerButtonProps> = ({ regionId }) => {
   return (
     <PrimaryButton
       text={`Add ${regions[regionId]} Customer`}
-      onPress={() => navigate(Screen.AddCustomer)}
+      onPress={() => navigate(Screen.AddCustomer, { regionId })}
     />
   );
 };

--- a/src/screens/EditCustomer.tsx
+++ b/src/screens/EditCustomer.tsx
@@ -1,14 +1,11 @@
 import React from "react";
 import { CustomerDataForm } from "../components/CustomerDataForm";
-import { useGetCustomersReducer } from "../store/hooks/useGetCustomersReducer";
 import { RouteProp, useRoute } from "@react-navigation/native";
 import { RootStackParamList } from "../../App";
 import { ActivityIndicator, Text, View } from "react-native";
 import { appStyles } from "../styles/main";
 
 export const EditCustomer: React.FC = () => {
-  const { saveCustomer, isLoadingSaveCustomer, errorSaveCustomer } =
-    useGetCustomersReducer();
   const { params } = useRoute<RouteProp<RootStackParamList, "EditCustomer">>();
 
   const customerToEdit = params?.customer;
@@ -33,12 +30,6 @@ export const EditCustomer: React.FC = () => {
   }
 
   return (
-    <CustomerDataForm
-      existingCustomer={customerToEdit}
-      canDelete={true}
-      onSave={saveCustomer}
-      isDisabled={isLoadingSaveCustomer}
-      error={errorSaveCustomer}
-    />
+    <CustomerDataForm existingCustomer={customerToEdit} canDelete={true} />
   );
 };

--- a/src/screens/Welcome.tsx
+++ b/src/screens/Welcome.tsx
@@ -40,44 +40,25 @@ export const Welcome: React.FC = () => {
   };
 
   return (
-    <View
-      style={{
-        ...appStyles.container,
-        justifyContent: "space-between",
-      }}
-    >
-      <View
-        style={{
-          flex: 1,
-          width: "100%",
-          alignItems: "center",
-          justifyContent: "center",
-        }}
-      >
-        <Text style={{ marginBottom: 8 }}>
-          Select an option below to continue
-        </Text>
-        <PrimaryButton
-          text="View customers by region"
-          onPress={() => navigate(Screen.RegionList)}
-        />
-        <PrimaryButton
-          text="Add new customer"
-          onPress={() => navigate(Screen.AddCustomer)}
-        />
-      </View>
-
+    <View style={appStyles.container}>
+      <Text style={{ marginBottom: 8 }}>
+        Select an option below to continue
+      </Text>
+      <PrimaryButton
+        text="View customers by region"
+        onPress={() => navigate(Screen.RegionList)}
+      />
+      <DangerousButton
+        text="Clear all customer data"
+        onPress={showClearCustomerDataAlert}
+        disabled={isLoadingResetCustomers}
+      />
       {errorResetCustomers && (
         <Text style={appStyles.errorText}>
           We're sorry, there was an error clearing the customer data. Please try
           again later.
         </Text>
       )}
-      <DangerousButton
-        text="Clear all customer data"
-        onPress={showClearCustomerDataAlert}
-        disabled={isLoadingResetCustomers}
-      />
     </View>
   );
 };

--- a/src/store/hooks/useGetCustomersReducer.tsx
+++ b/src/store/hooks/useGetCustomersReducer.tsx
@@ -26,6 +26,9 @@ export const useGetCustomersReducer = () => {
   const errorSaveCustomer = useSelector(
     (state: RootState) => state.customersReducer.errorSaveCustomer
   );
+  const isRequestedDeleteCustomer = useSelector(
+    (state: RootState) => state.customersReducer.isRequestedDeleteCustomer
+  );
   const isLoadingDeleteCustomer = useSelector(
     (state: RootState) => state.customersReducer.isLoadingDeleteCustomer
   );
@@ -50,10 +53,14 @@ export const useGetCustomersReducer = () => {
     saveCustomer: (customer: Customer) => {
       return dispatch(actions.saveCustomer(customer));
     },
+    isRequestedDeleteCustomer,
     isLoadingDeleteCustomer,
     errorDeleteCustomer,
     deleteCustomer: (customerId: number) => {
       return dispatch(actions.deleteCustomer(customerId));
+    },
+    resetRequestDeleteCustomer: () => {
+      return dispatch(actions.deleteCustomerResetRequest());
     },
   };
 };

--- a/src/store/hooks/useGetCustomersReducer.tsx
+++ b/src/store/hooks/useGetCustomersReducer.tsx
@@ -20,6 +20,9 @@ export const useGetCustomersReducer = () => {
   const errorResetCustomers = useSelector(
     (state: RootState) => state.customersReducer.errorResetCustomers
   );
+  const isRequestedSaveCustomer = useSelector(
+    (state: RootState) => state.customersReducer.isRequestedSaveCustomer
+  );
   const isLoadingSaveCustomer = useSelector(
     (state: RootState) => state.customersReducer.isLoadingSaveCustomer
   );
@@ -48,10 +51,14 @@ export const useGetCustomersReducer = () => {
     resetCustomers: () => {
       return dispatch(actions.resetCustomers());
     },
+    isRequestedSaveCustomer,
     isLoadingSaveCustomer,
     errorSaveCustomer,
     saveCustomer: (customer: Customer) => {
       return dispatch(actions.saveCustomer(customer));
+    },
+    resetRequestSaveCustomer: () => {
+      return dispatch(actions.saveCustomerResetRequest());
     },
     isRequestedDeleteCustomer,
     isLoadingDeleteCustomer,

--- a/src/store/reducers/customersReducer.tsx
+++ b/src/store/reducers/customersReducer.tsx
@@ -16,6 +16,7 @@ interface CustomersReducerState {
   errorResetCustomers: string | null;
   isLoadingSaveCustomer: boolean;
   errorSaveCustomer: string | null;
+  isRequestedDeleteCustomer: boolean;
   isLoadingDeleteCustomer: boolean;
   errorDeleteCustomer: string | null;
 }
@@ -29,6 +30,7 @@ const slice = createSlice({
     errorResetCustomers: null,
     isLoadingSaveCustomer: false,
     errorSaveCustomer: null,
+    isRequestedDeleteCustomer: false,
     isLoadingDeleteCustomer: false,
     errorDeleteCustomer: null,
   } satisfies CustomersReducerState as CustomersReducerState,
@@ -70,6 +72,7 @@ const slice = createSlice({
       state.errorSaveCustomer = action.payload;
     },
     deleteCustomer: (state, action: PayloadAction<number>) => {
+      state.isRequestedDeleteCustomer = true;
       state.isLoadingDeleteCustomer = true;
       state.errorDeleteCustomer = null;
     },
@@ -78,8 +81,12 @@ const slice = createSlice({
       state.customers = action.payload;
     },
     deleteCustomerError: (state, action: PayloadAction<string>) => {
+      state.isRequestedDeleteCustomer = false;
       state.isLoadingDeleteCustomer = false;
       state.errorDeleteCustomer = action.payload;
+    },
+    deleteCustomerResetRequest: (state) => {
+      state.isRequestedDeleteCustomer = false;
     },
   },
 });
@@ -97,6 +104,7 @@ export const {
   deleteCustomer,
   deleteCustomerResult,
   deleteCustomerError,
+  deleteCustomerResetRequest,
 } = slice.actions;
 
 export default slice.reducer;

--- a/src/store/reducers/customersReducer.tsx
+++ b/src/store/reducers/customersReducer.tsx
@@ -14,6 +14,7 @@ interface CustomersReducerState {
   errorSyncCustomers: string | null;
   isLoadingResetCustomers: boolean;
   errorResetCustomers: string | null;
+  isRequestedSaveCustomer: boolean;
   isLoadingSaveCustomer: boolean;
   errorSaveCustomer: string | null;
   isRequestedDeleteCustomer: boolean;
@@ -28,6 +29,7 @@ const slice = createSlice({
     errorSyncCustomers: null,
     isLoadingResetCustomers: false,
     errorResetCustomers: null,
+    isRequestedSaveCustomer: false,
     isLoadingSaveCustomer: false,
     errorSaveCustomer: null,
     isRequestedDeleteCustomer: false,
@@ -60,6 +62,7 @@ const slice = createSlice({
       state.errorResetCustomers = action.payload;
     },
     saveCustomer: (state, action: PayloadAction<Customer>) => {
+      state.isRequestedSaveCustomer = true;
       state.isLoadingSaveCustomer = true;
       state.errorSaveCustomer = null;
     },
@@ -68,8 +71,12 @@ const slice = createSlice({
       state.customers = action.payload;
     },
     saveCustomerError: (state, action: PayloadAction<string>) => {
+      state.isRequestedSaveCustomer = false;
       state.isLoadingSaveCustomer = false;
       state.errorSaveCustomer = action.payload;
+    },
+    saveCustomerResetRequest: (state) => {
+      state.isRequestedSaveCustomer = false;
     },
     deleteCustomer: (state, action: PayloadAction<number>) => {
       state.isRequestedDeleteCustomer = true;
@@ -101,6 +108,7 @@ export const {
   saveCustomer,
   saveCustomerResult,
   saveCustomerError,
+  saveCustomerResetRequest,
   deleteCustomer,
   deleteCustomerResult,
   deleteCustomerError,


### PR DESCRIPTION
## Changes

- Moves add customer functionality solely to individual region lists. Now, when adding a customer for a specific region, the region will pre-populate in the customer data form.
- When adding or editing a customer, tapping the "Cancel" button will navigate back to the previous screen.
- When adding or editing a customer, tapping the "Save" button will successfully save the customer and navigate back to the customer list for the region where the customer was added.
- Upon deleting a customer, the user will be taken back to the customer list for the region where the deleted customer was previously found.

## What it looks like
https://github.com/meggra7/udacity-react-native-project/assets/98534801/d59c2e37-5b68-47e4-927f-d9850dcc1151

## "Ticket"

### Description
This task is to primarily ensure that all navigation nuances are wired up correctly.

### Acceptance criteria

- [x] Upon successfully adding or editing a customer, navigate to the view customer page for that customer that will navigate back to the region for that customer
- [x] Upon successfully deleting a customer, navigate to the customer list for that customer's region
- [x] Upon clicking to add a customer from a specific region list, pass in the region id to pre-populate the region
- [x] Canceling from the add/edit customer screen should navigate back to the prior screen